### PR TITLE
feat: support ZTunnel vendor defaults and add v1.30.3 ztunnel resource limits

### DIFF
--- a/pkg/istiovalues/vendor_defaults.go
+++ b/pkg/istiovalues/vendor_defaults.go
@@ -92,8 +92,27 @@ func ApplyIstioCNIVendorDefaults(version string, values *v1.CNIValues) (*v1.CNIV
 	return finalValues, nil
 }
 
+// ApplyZTunnelVendorDefaults applies vendor-specific default values to the provided
+// ZTunnel configuration (*v1.ZTunnelValues) for a given Istio version.
+func ApplyZTunnelVendorDefaults(version string, values *v1.ZTunnelValues) (*v1.ZTunnelValues, error) {
+	// Convert the specific *v1.ZTunnelValues struct to a generic map[string]any
+	userHelmValues := helm.FromValues(values)
+
+	mergedHelmValues, err := applyVendorDefaultsForResourceType(version, v1.ZTunnelKind, userHelmValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply vendor defaults for ztunnel: %w", err)
+	}
+
+	finalValues, err := helm.ToValues(mergedHelmValues, &v1.ZTunnelValues{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert merged values back to *v1.ZTunnelValues: %w", err)
+	}
+
+	return finalValues, nil
+}
+
 // applyVendorDefaultsForResourceType retrieves defaults for
-// a given version and resourceType, current valid resources are: "istio" and "istiocni"
+// a given version and resourceType, current valid resources are: "istio", "istiocni" and "ztunnel"
 // It returns the merged map and an error if the defaults are not found or malformed.
 // The userValuesMap is the 'base', and resource-specific defaults are 'overrides'.
 func applyVendorDefaultsForResourceType(version, resourceType string, userValuesMap map[string]any) (map[string]any, error) {

--- a/pkg/istiovalues/vendor_defaults.yaml
+++ b/pkg/istiovalues/vendor_defaults.yaml
@@ -1,8 +1,8 @@
 # This file can be overwritten in vendor distributions of sail-operator to set
 # vendor-specific defaults. You can configure version-specific defaults for
-# every field in `spec.values` for both Istio and IstioCNI resource, 
+# every field in `spec.values` for the Istio, IstioCNI and ZTunnel resources,
 # see the following example:
-# 
+#
 # v1.26.0:
 #   istio:
 #     pilot:
@@ -11,6 +11,12 @@
 #   istiocni:
 #     cni:
 #       cniConfDir: custom/cni/conf/dir
+#   ztunnel:
+#     ztunnel:
+#       resources:
+#         limits:
+#           cpu: "2000m"
+#           memory: 1024Mi
 #
 # These defaults are type-checked at compile time.
 # Note: After modifying this file, run `make test` to ensure that the
@@ -34,6 +40,12 @@ v1.30.3:
       resources:
         limits:
           cpu: "1000m"
+          memory: 1024Mi
+  ztunnel:
+    ztunnel:
+      resources:
+        limits:
+          cpu: "2000m"
           memory: 1024Mi
 v1.28.6:
   istio:

--- a/pkg/istiovalues/vendor_defaults_test.go
+++ b/pkg/istiovalues/vendor_defaults_test.go
@@ -22,6 +22,8 @@ import (
 	v1 "github.com/istio-ecosystem/sail-operator/api/v1"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"istio.io/istio/pkg/ptr"
 )
@@ -275,6 +277,119 @@ v1.24.2:
 	}
 }
 
+func TestApplyZTunnelVendorDefaults(t *testing.T) {
+	ztunnelLimits := &v1.ZTunnelValues{
+		ZTunnel: &v1.ZTunnelConfig{
+			Resources: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+					corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				},
+			},
+		},
+	}
+
+	testcases := []struct {
+		name                 string
+		vendorDefaults       string
+		version              string
+		preValues            *v1.ZTunnelValues
+		postValues           *v1.ZTunnelValues
+		expectedError        bool
+		expectedErrSubstring string
+	}{
+		{
+			name: "adding resource limits for ZTunnel",
+			vendorDefaults: `
+v1.24.2:
+  ztunnel:
+    ztunnel:
+      resources:
+        limits:
+          cpu: "2000m"
+          memory: 1024Mi
+`,
+			version:    "v1.24.2",
+			preValues:  &v1.ZTunnelValues{},
+			postValues: ztunnelLimits,
+		},
+		{
+			name: "user values override and merge with vendor defaults",
+			vendorDefaults: `
+v1.24.2:
+  ztunnel:
+    ztunnel:
+      resources:
+        limits:
+          cpu: "2000m"
+          memory: 1024Mi
+`,
+			version: "v1.24.2",
+			preValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3000m"),
+						},
+					},
+				},
+			},
+			postValues: &v1.ZTunnelValues{
+				ZTunnel: &v1.ZTunnelConfig{
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("3000m"), // user value takes precedence
+							corev1.ResourceMemory: resource.MustParse("1024Mi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no ztunnel defaults defined for this version",
+			vendorDefaults: `
+v1.24.2:
+  istio:
+    pilot:
+      env:
+        someEnvVar: "true"
+`,
+			version:    "v1.24.2",
+			preValues:  &v1.ZTunnelValues{},
+			postValues: &v1.ZTunnelValues{},
+		},
+		{
+			name: "malformed ztunnel defaults",
+			vendorDefaults: `
+v1.24.2:
+  ztunnel:
+    ztunnel: "resources"
+`,
+			version:              "v1.24.2",
+			preValues:            &v1.ZTunnelValues{},
+			postValues:           nil, // expect nil due to malformed defaults
+			expectedError:        true,
+			expectedErrSubstring: "cannot unmarshal string into Go struct field ZTunnelValues.ztunnel",
+		},
+	}
+	for _, tc := range testcases {
+		vendorDefaults = MustParseVendorDefaultsYAML([]byte(tc.vendorDefaults))
+
+		result, err := ApplyZTunnelVendorDefaults(tc.version, tc.preValues)
+		if tc.expectedError {
+			if assert.Error(t, err, "expected an error for ZTunnel on %s but got none", tc.name) {
+				assert.ErrorContains(t, err, tc.expectedErrSubstring,
+					"ZTunnel default values on %s should unwrap JSON-unmarshal errors", tc.name)
+			}
+		} else {
+			assert.NoError(t, err, "unexpected error for ZTunnel on %s: %v", tc.name, err)
+		}
+		if diff := cmp.Diff(tc.postValues, result); diff != "" {
+			t.Errorf("unexpected ZTunnel merge result on %s; diff (-expected, +actual):\n%v", tc.name, diff)
+		}
+	}
+}
+
 func TestValidateVendorDefaultsFile(t *testing.T) {
 	defaultsYAML, err := os.ReadFile("vendor_defaults.yaml")
 	if err != nil {
@@ -288,7 +403,15 @@ func TestValidateVendorDefaultsFile(t *testing.T) {
 	for version := range vendorDefaults {
 		_, err := ApplyIstioVendorDefaults(version, &v1.Values{})
 		if err != nil {
-			t.Errorf("failed to parse vendor_defaults.yaml at version %s: %v", version, err)
+			t.Errorf("failed to parse istio defaults in vendor_defaults.yaml at version %s: %v", version, err)
+		}
+		_, err = ApplyIstioCNIVendorDefaults(version, &v1.CNIValues{})
+		if err != nil {
+			t.Errorf("failed to parse istiocni defaults in vendor_defaults.yaml at version %s: %v", version, err)
+		}
+		_, err = ApplyZTunnelVendorDefaults(version, &v1.ZTunnelValues{})
+		if err != nil {
+			t.Errorf("failed to parse ztunnel defaults in vendor_defaults.yaml at version %s: %v", version, err)
 		}
 	}
 }

--- a/pkg/reconcile/ztunnel.go
+++ b/pkg/reconcile/ztunnel.go
@@ -86,6 +86,12 @@ func (r *ZTunnelReconciler) ComputeValues(version string, userValues *v1.ZTunnel
 	// Apply image digests from configuration, if not already set by user
 	userValues = ApplyZTunnelImageDigests(resolvedVersion, userValues, config.Config)
 
+	// Apply vendor-specific default values
+	userValues, err = istiovalues.ApplyZTunnelVendorDefaults(resolvedVersion, userValues)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply vendor defaults: %w", err)
+	}
+
 	// apply fips values
 	istiovalues.ApplyZTunnelFipsValues(userValues)
 


### PR DESCRIPTION
## Why

Per the resource specification, every istio component must define resource limits. In an ambient-mode deployment, ztunnel was the only component shipped without limits:

| Component | Limits | Source |
|---|---|---|
| istiod | 2 / 4Gi | vendor_defaults.yaml |
| istio-cni-node | 1 / 1Gi | vendor_defaults.yaml |
| waypoint | 2 / 1Gi | chart default |
| ztunnel | **none** | — |

Root cause: the vendor defaults mechanism only supported the `Istio` and `IstioCNI` resources (`vendor_defaults.go`, "current valid resources are: istio and istiocni"), so ztunnel had no vendor-level channel to receive default limits.

## What

- Add `ApplyZTunnelVendorDefaults` to `pkg/istiovalues/vendor_defaults.go`, following the same pattern used when IstioCNI support was added (istio-ecosystem#845).
- Wire it into `ZTunnelReconciler.ComputeValues` (after image digests, before FIPS values), mirroring the CNI reconciler.
- Set default resource limits for **v1.30.3 only** in `vendor_defaults.yaml`:
  ```yaml
  ztunnel:
    ztunnel:
      resources:
        limits:
          cpu: "2000m"
          memory: 1024Mi
  ```
  The values match the default limits of the other data plane proxies (sidecar `2000m/1024Mi`, waypoint `2/1Gi`). Older versions (v1.28.x) are intentionally left unchanged.
- Merge semantics: vendor defaults are the base and user values are the override, so any `spec.values.ztunnel.resources` set explicitly in a ZTunnel CR still takes precedence.

## Testing

- New `TestApplyZTunnelVendorDefaults` unit test: basic merge, user-override deep-merge (user cpu wins, vendor memory fills in), version without ztunnel defaults, malformed defaults error.
- Extended `TestValidateVendorDefaultsFile` to type-check the `istio`, `istiocni` **and** `ztunnel` sections of `vendor_defaults.yaml` (previously only `istio` was validated).
- `make build`, `golangci-lint` (0 issues), and the full unit test suite pass locally. (`lint-scripts` / `lint-copyright-banner` fail on `main` as well due to pre-existing `.claude/skills` shell scripts — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
